### PR TITLE
[v1.1.0] Add markdown overrides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ insert_final_newline = true
 max_line_length = 140
 trim_trailing_whitespace = true
 
-[*.{css,scss}]
+[*.{css,scss,md,markdown}]
     indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+# 1.1.0
+
+- Adds override for `tabWidth` on markdown files to help with frontmatter formatting.
+
 # 1.0.0
 
 - Improves usage instructions
-- Adds linting and formating
+- Adds linting and formatting
 
 # 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm install --save-dev prettier @stackbit/prettier-config
 ```
 
 ## Usage
+
 Stackbit's Prettier rules come bundled in `@stackbit/prettier-config`. To enable these rules, add a `prettier` property in your `package.json`. See the [Prettier configuration docs](https://prettier.io/docs/en/configuration.html) for more details.
 
 ```json
@@ -37,11 +38,15 @@ To extend a configuration you will need to use a `prettier.config.js` or `.prett
 
 ```javascript
 module.exports = {
-    ...require('@stackbit/prettier-config'),
-    semi: false
+  ...require('@stackbit/prettier-config'),
+  semi: false
 };
 ```
 
-## [CHANGELOG](CHANGELOG.md)
+## Changelog
 
-## [LICENSE](LICENSE)
+Changes are recorded in [`CHANGELOG.md`](CHANGELOG.md).
+
+## License
+
+Distributed under the MIT License. See [`LICENSE`](LICENSE) for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stackbit/prettier-config",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Stackbit's shareable config for prettier",
     "author": "Stackbit Inc.",
     "license": "MIT",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -8,6 +8,12 @@ module.exports = {
                 tabWidth: 2,
                 singleQuote: false
             }
+        },
+        {
+            files: ['*.md', '*.markdown'],
+            options: {
+                tabWidth: 2
+            }
         }
     ],
     semi: true,


### PR DESCRIPTION
VS Code is indenting YAML frontmatter in markdown files with four spaces. That may be what we want, but it also conflicts with the content that Stackbit app generates for us.

IOW if I make a change in Stackbit and then pull the changes down and save the file locally, they are overwritten. Structurally, four spaces in the YAML frontmatter works just fine. My assumption here is that we'd want parity among local formatters and output generated by the app.